### PR TITLE
Add BSD 2-Clause License

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Jules Blok
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
You don't have a license! BSD is simple enough, imo. Feel free to choose another if you want. This concerns me, since I have [a fork](https://github.com/forivall/niftykb-ts3) that receives commands over IPC instead of debugger messages.

As for any concerns about creating an open source plugin for a piece of closed source software, I looked to foobar2000 plugins for "prior art", and [columns_ui](https://github.com/msquared2/columns_ui) uses GPL/LGPL.

I also took a quick look through your other non-fork repos to see if you have used licenses on your, and I see that you've used the LGPL. That would be great too.

If you need a refresher on licenses, github's [choosealicense.com](http://choosealicense.com/) is nifty.
